### PR TITLE
Streamlined websocket feed message postprocessing

### DIFF
--- a/src/main/java/com/melonbar/exchange/coinbase/util/JsonUtils.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/util/JsonUtils.java
@@ -5,6 +5,11 @@ package com.melonbar.exchange.coinbase.util;
  */
 public final class JsonUtils {
 
+    private static final char QUOTE = '\"';
+    private static final char SEMICOLON = ':';
+    private static final char COMMA = ',';
+    private static final char CLOSE_BRACKET = '}';
+
     /**
      * Extracts the string value from the input <code>jsonString</code> using input <code>key</code> as
      * the json key. The input key should be the raw string value, and not contain any extraneous quotations or
@@ -25,7 +30,7 @@ public final class JsonUtils {
     public static String extractField(final String key, final String jsonString) {
         Guard.nonNull(key, jsonString);
         final String stripped = jsonString.replaceAll("\\s", "");
-        final String quotedKey = '\"' + key + '\"' + ':';
+        final String quotedKey = QUOTE + key + QUOTE + SEMICOLON;
         final int typeFieldIndex = stripped.indexOf(quotedKey);
         if (typeFieldIndex < 0) {
             return null;
@@ -34,9 +39,9 @@ public final class JsonUtils {
         int startIndex = typeFieldIndex + quotedKey.length();
         int endIndex = stripped.indexOf(
                 // if no comma present after start index, then assume key is last element
-                stripped.indexOf(',', startIndex) > 0 ? "," : "}", typeFieldIndex);
+                stripped.indexOf(COMMA, startIndex) > 0 ? COMMA : CLOSE_BRACKET, typeFieldIndex);
         // determine if quotes must be stripped
-        if (stripped.charAt(startIndex) == '\"') {
+        if (stripped.charAt(startIndex) == QUOTE) {
             startIndex += 1;
             endIndex -= 1;
         }

--- a/src/main/java/com/melonbar/exchange/coinbase/util/JsonUtils.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/util/JsonUtils.java
@@ -1,0 +1,46 @@
+package com.melonbar.exchange.coinbase.util;
+
+/**
+ * Simple static utilities for json string manipulation. All methods should be stateless, and thus thread-safe.
+ */
+public final class JsonUtils {
+
+    /**
+     * Extracts the string value from the input <code>jsonString</code> using input <code>key</code> as
+     * the json key. The input key should be the raw string value, and not contain any extraneous quotations or
+     * semicolons since this method handles adding it in before parsing. Furthermore, it is up to the caller to
+     * ensure the input json string is in a valid json format, otherwise the resultant behavior is undefined.
+     *
+     * <p> Basic usage example:
+     * <pre>
+     *     String jsonString = "{\"key0\":\"value0\", \"key1\":1001}"
+     *     extractField("key0", jsonString); // outputs "value0", quotes stripped
+     *     extractField("key1", jsonString); // outputs "1001"
+     * </pre>
+     *
+     * @param key Key for value to be extracted
+     * @param jsonString Json string
+     * @return Json value
+     */
+    public static String extractField(final String key, final String jsonString) {
+        Guard.nonNull(key, jsonString);
+        final String stripped = jsonString.replaceAll("\\s", "");
+        final String quotedKey = '\"' + key + '\"' + ':';
+        final int typeFieldIndex = stripped.indexOf(quotedKey);
+        if (typeFieldIndex < 0) {
+            return null;
+        }
+        // determine beginning and end indices for value extraction
+        int startIndex = typeFieldIndex + quotedKey.length();
+        int endIndex = stripped.indexOf(
+                stripped.indexOf(',') > 0 ? "," : "}", typeFieldIndex);
+        // determine if quotes must be stripped
+        if (stripped.charAt(startIndex) == '\"') {
+            startIndex += 1;
+            endIndex -= 1;
+        }
+        return stripped
+                .substring(startIndex, endIndex)
+                .trim();
+    }
+}

--- a/src/main/java/com/melonbar/exchange/coinbase/util/JsonUtils.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/util/JsonUtils.java
@@ -33,7 +33,8 @@ public final class JsonUtils {
         // determine beginning and end indices for value extraction
         int startIndex = typeFieldIndex + quotedKey.length();
         int endIndex = stripped.indexOf(
-                stripped.indexOf(',') > 0 ? "," : "}", typeFieldIndex);
+                // if no comma present after start index, then assume key is last element
+                stripped.indexOf(',', startIndex) > 0 ? "," : "}", typeFieldIndex);
         // determine if quotes must be stripped
         if (stripped.charAt(startIndex) == '\"') {
             startIndex += 1;

--- a/src/main/java/com/melonbar/exchange/coinbase/websocket/CoinbaseProWebsocketFeedClient.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/websocket/CoinbaseProWebsocketFeedClient.java
@@ -4,9 +4,10 @@ import com.melonbar.exchange.coinbase.model.core.ProductId;
 import com.melonbar.exchange.coinbase.util.AppConfig;
 import com.melonbar.exchange.coinbase.websocket.message.SubscribeMessage;
 import com.melonbar.exchange.coinbase.websocket.message.model.Channel;
-import com.melonbar.exchange.coinbase.websocket.processing.StringMessageHandler;
+import com.melonbar.exchange.coinbase.websocket.processing.AggregatedMessageHandler;
 
 import javax.websocket.ClientEndpoint;
+import javax.websocket.MessageHandler;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -37,12 +38,13 @@ public class CoinbaseProWebsocketFeedClient extends ReactiveWebsocketFeedClient 
     }
 
     /**
-     * Add {@link StringMessageHandler}s to the member {@lnk AggregatedMessageHandler}.
+     * Add {@link MessageHandler.Whole}s to the member {@link AggregatedMessageHandler}.
      *
-     * @param messageHandlers {@link StringMessageHandler Handler(s)} to add
+     * @param messageHandlers {@link MessageHandler.Whole Handler(s)} to add
      */
-    public void addMessageHandlers(final StringMessageHandler ... messageHandlers) {
-        for (final StringMessageHandler messageHandler : messageHandlers) {
+    @SafeVarargs
+    public final void addMessageHandlers(final MessageHandler.Whole<String>... messageHandlers) {
+        for (final MessageHandler.Whole<String> messageHandler : messageHandlers) {
             getAggregatedMessageHandler().addMessageHandler(messageHandler);
         }
     }
@@ -66,12 +68,13 @@ public class CoinbaseProWebsocketFeedClient extends ReactiveWebsocketFeedClient 
         }
 
         /**
-         * Wither for {@link StringMessageHandler}s.
+         * Wither for {@link MessageHandler.Whole}s.
          *
-         * @param messageHandlers {@link StringMessageHandler}s
+         * @param messageHandlers {@link MessageHandler.Whole}s
          * @return {@link Builder}
          */
-        public Builder withMessageHandlers(final StringMessageHandler ... messageHandlers) {
+        @SafeVarargs
+        public final Builder withMessageHandlers(final MessageHandler.Whole<String>... messageHandlers) {
             coinbaseProWebsocketFeedClient.addMessageHandlers(messageHandlers);
             return this;
         }

--- a/src/main/java/com/melonbar/exchange/coinbase/websocket/message/FeedMessage.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/websocket/message/FeedMessage.java
@@ -37,7 +37,7 @@ import org.joda.time.DateTime;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = FeedMessage.TYPE_FIELD)
 @JsonSubTypes({
         // request message types
         @JsonSubTypes.Type(value = SubscribeMessage.class,      name = MessageTypes.SUBSCRIBE),
@@ -59,6 +59,8 @@ import org.joda.time.DateTime;
         @JsonSubTypes.Type(value = ActivatedOrderMessage.class, name = MessageTypes.ACTIVATED_ORDER),
 })
 public abstract class FeedMessage implements Message {
+
+    public static final String TYPE_FIELD = "type";
 
     @JsonProperty("sequence") private Long sequence;
     @JsonProperty("time") private DateTime time;
@@ -82,17 +84,6 @@ public abstract class FeedMessage implements Message {
      */
     @Override
     public String toString() {
-        return getText();
-    }
-
-    /**
-     * Use json marshalling method to provide json value when extensions of {@link FeedMessage} are being
-     * serialized.
-     *
-     * @return Json representation
-     */
-    @JsonValue
-    public String toJson() {
         return getText();
     }
 

--- a/src/main/java/com/melonbar/exchange/coinbase/websocket/message/deserializer/JsonMessageMapper.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/websocket/message/deserializer/JsonMessageMapper.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.melonbar.exchange.coinbase.model.core.ProductId;
+import com.melonbar.exchange.coinbase.util.JsonUtils;
 import com.melonbar.exchange.coinbase.websocket.MessageTypes;
 import com.melonbar.exchange.coinbase.websocket.message.FeedMessage;
 import com.melonbar.exchange.coinbase.websocket.message.model.L2OrderTuple;
@@ -35,7 +36,6 @@ import java.util.Optional;
 public class JsonMessageMapper {
 
     private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private final static String TYPE_FIELD = "\"type\":";
 
     static {
         final SimpleModule websocketFeedMessageModule = new SimpleModule();
@@ -95,22 +95,9 @@ public class JsonMessageMapper {
      * @see MessageTypes
      */
     public static Optional<? extends FeedMessage> jsonToObject(final String jsonString) {
-        final String type = extractType(jsonString);
+        final String type = JsonUtils.extractField(FeedMessage.TYPE_FIELD, jsonString);
         return StringUtils.isEmpty(type)
                 ? Optional.empty()
                 : jsonToObject(jsonString, MessageTypes.evaluateMessageType(type));
-    }
-
-    private static String extractType(final String jsonString) {
-        final String stripped = jsonString.replaceAll("\\s", "");
-        final int typeFieldIndex = stripped.indexOf(TYPE_FIELD);
-        if (typeFieldIndex < 0) {
-            return null;
-        }
-        // if there exists only 1 json field, suffix will be close bracket instead of comma
-        final int endIndex = stripped.indexOf(stripped.indexOf(',') > 0 ? "," : "}", typeFieldIndex)-1;
-        return stripped
-                .substring(typeFieldIndex+TYPE_FIELD.length()+1, endIndex)
-                .trim();
     }
 }

--- a/src/main/java/com/melonbar/exchange/coinbase/websocket/processing/MessageHandlers.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/websocket/processing/MessageHandlers.java
@@ -1,0 +1,66 @@
+package com.melonbar.exchange.coinbase.websocket.processing;
+
+import com.melonbar.exchange.coinbase.util.Guard;
+import com.melonbar.exchange.coinbase.util.JsonUtils;
+import com.melonbar.exchange.coinbase.websocket.message.FeedMessage;
+import com.melonbar.exchange.coinbase.websocket.processing.predicated.PredicatedMessageHandler;
+
+import javax.websocket.MessageHandler;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Catalog of common helper functions and {@link MessageHandler} generators for general use cases.
+ */
+public final class MessageHandlers {
+
+    private static final String TICKER_PRICE = "price";
+
+    /**
+     * Function that accepts ticker json message and extracts the current price.
+     *
+     * @return {@link StringMessageFunction} for extracting price from inbound ticker
+     */
+    public static StringMessageFunction<BigDecimal> getPriceFromTicker() {
+        return (message) -> new BigDecimal(
+                Objects.requireNonNull(
+                        JsonUtils.extractField(TICKER_PRICE, message)));
+    }
+
+    /**
+     * Factory method for creating {@link PredicatedMessageHandler} provided an input {@link Predicate} on
+     * {@link T} and the base {@link MessageHandler.Whole}.
+     *
+     * @param messageHandler Base handler whose {@link MessageHandler.Whole#onMessage} will be invoked
+     * @param predicate {@link Predicate} guarding invocation
+     * @param <T> Message type
+     * @return {@link PredicatedMessageHandler}
+     */
+    public static <T> PredicatedMessageHandler<T> predicated(final MessageHandler.Whole<T> messageHandler,
+                                                             final Predicate<T> predicate) {
+        return new PredicatedMessageHandler<T>(predicate, messageHandler);
+    }
+
+    /**
+     * Aggregates {@link StringMessageHandler} by the json message type, defined by its <code>type</code> field.
+     * Each {@link StringMessageHandler} is converted into a {@link PredicatedMessageHandler} by applying a new
+     * {@link Predicate} that checks equality between input <code>type</code> and the corresponding key value
+     * from an inbound json message. If the type matches, then the {@link AggregatedMessageHandler} is invoked.
+     *
+     * @param type Expected type
+     * @param messageHandlers {@link StringMessageHandler}s to aggregate into {@link AggregatedMessageHandler}
+     * @return {@link PredicatedMessageHandler}
+     */
+    public static PredicatedMessageHandler<String> byType(final String type,
+                                                          final StringMessageHandler ... messageHandlers) {
+        Guard.nonNull(type, messageHandlers);
+        final AggregatedMessageHandler<String> aggregate = AggregatedMessageHandler.create();
+        Arrays.stream(messageHandlers)
+                .forEach(aggregate::addMessageHandler);
+        // predicate aggregation of input message handlers with type field check
+        return predicated(aggregate,
+                (message) -> type.equals(JsonUtils.extractField(FeedMessage.TYPE_FIELD, message)));
+    }
+}

--- a/src/main/java/com/melonbar/exchange/coinbase/websocket/processing/StringMessageFunction.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/websocket/processing/StringMessageFunction.java
@@ -1,0 +1,12 @@
+package com.melonbar.exchange.coinbase.websocket.processing;
+
+import java.util.function.Function;
+
+/**
+ * Generic interface extension of {@link Function} for accepting {@link String} types.
+ *
+ * @param <T> Resultant type
+ */
+public interface StringMessageFunction<T> extends Function<String, T> {
+
+}

--- a/src/main/java/com/melonbar/exchange/coinbase/websocket/processing/predicated/PredicatedMessageHandler.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/websocket/processing/predicated/PredicatedMessageHandler.java
@@ -1,0 +1,31 @@
+package com.melonbar.exchange.coinbase.websocket.processing.predicated;
+
+import lombok.RequiredArgsConstructor;
+
+import javax.websocket.MessageHandler;
+import java.util.function.Predicate;
+
+/**
+ * Generalized wrapper for {@link MessageHandler.Whole} that guards {@link #onMessage} invocation using the
+ * provided {@link Predicate}.
+ *
+ * @param <T> Message type
+ */
+@RequiredArgsConstructor
+public class PredicatedMessageHandler<T> implements MessageHandler.Whole<T> {
+
+    private final Predicate<T> predicate;
+    private final MessageHandler.Whole<T> handler;
+
+    /**
+     * Guarded invocation of <code>handler#onMessage</code> by input {@link Predicate}.
+     *
+     * @param message Message
+     */
+    @Override
+    public final void onMessage(final T message) {
+        if (predicate.test(message)) {
+            handler.onMessage(message);
+        }
+    }
+}

--- a/src/main/java/com/melonbar/exchange/coinbase/websocket/subscribe/Subscriptions.java
+++ b/src/main/java/com/melonbar/exchange/coinbase/websocket/subscribe/Subscriptions.java
@@ -1,4 +1,0 @@
-package com.melonbar.exchange.coinbase.websocket.subscribe;
-
-public class Subscriptions {
-}


### PR DESCRIPTION
Changes:
1. `PredicatedMessageHandler`
    * basic wrapper for `MessageHandler.Whole` with invocation guarded by an input `Predicate`
    * allows convenient definition for less verbose message filtering, and unique behaviors defined by message type
2. `MessageHandlers`
    * static utilities class for defining common message handling use cases
    * see `MessageHandler#byType`
3. Minor changes
    * create `JsonUtils` static helper for json string manipulation
      * moved `JsonMessageMapper#extractField` to `JsonUtils#extractField`, modified it to enable extraction of non-string json values
    * deleted unused classes
    * more javadoc
    * generify `CoinbaseProWebsocketFeedClient` to accept any `MessageHandler.Whole<String>`
      * may remove `StringMessageHandler`, but currently still has some value in providing easy abstraction  for above type
      * needed generification to prevent limiting `MessageHandlers` utilities to only servicing `StringMessageHandler` types